### PR TITLE
litestar 2.21.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,0 @@
-staging_channel_upload_target: evidently-bootstrap
-
-channels:
-  - https://staging.continuum.io/pbp/evidently-bootstrap
-
-build_parameters:
-  - "--no-skip-existing"

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,3 +5,6 @@ channels:
 
 build_parameters:
   - "--no-skip-existing"
+
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314: yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,6 @@ staging_channel_upload_target: evidently-bootstrap
 
 channels:
   - https://staging.continuum.io/pbp/evidently-bootstrap
+
+build_parameters:
+  - "--no-skip-existing"

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,6 +5,3 @@ channels:
 
 build_parameters:
   - "--no-skip-existing"
-
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314: yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,4 @@
 upload_channels:
-  - sfe1ed40
+  - evidently-bootstrap
+source_channels:
+  - evidently-bootstrap

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,4 @@
-upload_channels:
-  - evidently-bootstrap
-source_channels:
-  - evidently-bootstrap
+staging_channel_upload_target: evidently-bootstrap
+
+channels:
+  - https://staging.continuum.io/pbp/evidently-bootstrap

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ outputs:
         - sniffio >=1.3.1
         - typing_extensions
       run_constrained:
-        - jinja2>=3.1.2
+        - jinja2 >=3.1.2
         - pyjwt>=2.9.0
         - mako>=1.2.4
         - minijinja>=1.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,9 +37,7 @@ outputs:
         - python
         - anyio >=3
         - httpx >=0.22
-        - exceptiongroup                # [py<311]
-        - importlib-metadata            # [py<310]
-        - importlib-resources >=5.12.0  # [py<39]
+        - exceptiongroup >=1.2.2        # [py<311]
         - litestar-htmx >=0.4.0
         - msgspec >=0.18.2
         - multidict >=6.0.2
@@ -56,6 +54,7 @@ outputs:
         - litestar
       commands:
         - pip check
+        - litestar --help
       requires:
         - pip
     about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -120,8 +120,6 @@ outputs:
       license_file: LICENSE
 
   - name: litestar-with-brotli
-    build:
-      noarch: generic
     requirements:
       build:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,7 +73,10 @@ outputs:
       dev_url: https://github.com/litestar-org/litestar
       doc_url: https://docs.litestar.dev
       summary: Light-weight and flexible ASGI API Framework
-      description: Light-weight and flexible ASGI API Framework
+      description: |
+        Litestar is a powerful, flexible yet opinionated ASGI framework, focused on building APIs.
+        It offers high-performance data validation, dependency injection, first-class ORM integration,
+        authorization primitives, a rich plugin API, middleware, and much more that's needed to get applications up and running.
       license: MIT
       license_family: MIT
       license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,4 @@
 {% set name = "litestar" %}
-{% set name = "litestar" %}
 {% set version = "2.21.1" %}
 
 package:
@@ -56,10 +55,10 @@ outputs:
       run_constrained:
         - jinja2 >=3.1.2
         - pyjwt >=2.9.0
-        - mako>=1.2.4
-        - minijinja>=1.0.0
+        - mako >=1.2.4
+        - minijinja >=1.0.0
         - hiredis >=4.4.4,<5.3
-        - advanced-alchemy>=0.2.2
+        - advanced-alchemy >=0.2.2
         - valkey >=6.0.2
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,6 +52,14 @@ outputs:
         - rich-click
         - sniffio >=1.3.1
         - typing_extensions
+      run_constrained:
+        - jinja2>=3.1.2
+        - pyjwt>=2.9.0
+        - mako>=1.2.4
+        - minijinja>=1.0.0
+        - hiredis >=4.4.4,<5.3
+        - advanced-alchemy>=0.2.2
+        - valkey >=6.0.2
     test:
       imports:
         - litestar

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,12 @@
-{% set version = "2.12.1" %}
+{% set version = "2.21.1" %}
 
 package:
   name: litestar-split
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/l/litestar/litestar-{{ version }}.tar.gz
-  sha256: d2cc43157060a06dac8a77e9dc6ba2936238beada61e272e8842c21fca23fcee
+  url: https://pypi.org/packages/source/l/litestar/litestar-{{ version }}.tar.gz
+  sha256: 28301438de7c5e77bb68a5d8684dff415b9f252b0dd8413b356e8e6794c6863a
 
 build:
   number: 0
@@ -40,13 +40,16 @@ outputs:
         - exceptiongroup                # [py<311]
         - importlib-metadata            # [py<310]
         - importlib-resources >=5.12.0  # [py<39]
+        - litestar-htmx >=0.4.0
         - msgspec >=0.18.2
         - multidict >=6.0.2
+        - multipart >=1.2.0
         - polyfactory >=2.6.3
         - pyyaml
         - click
         - rich >=13.0.0
         - rich-click
+        - sniffio >=1.3.1
         - typing_extensions
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,17 @@
+{% set name = "litestar" %}
 {% set version = "2.21.1" %}
 
 package:
-  name: litestar-split
+  name: {{ name }}-split
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/l/litestar/litestar-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 28301438de7c5e77bb68a5d8684dff415b9f252b0dd8413b356e8e6794c6863a
 
 build:
   number: 0
-  skip: true  # [py<39]
+  skip: true  # [py<38]
   # because of missing httpx for s390x
   skip: true  # [s390x]
 
@@ -23,7 +24,7 @@ requirements:
 outputs:
   - name: litestar
     build:
-      skip: true  # [py<39]
+      skip: true  # [py<38]
       script:
         - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
       entry_points:
@@ -38,6 +39,8 @@ outputs:
         - anyio >=3
         - httpx >=0.22
         - exceptiongroup >=1.2.2        # [py<311]
+        - importlib-metadata            # [py<310]
+        - importlib-resources >=5.12.0  # [py<39]
         - litestar-htmx >=0.4.0
         - msgspec >=0.18.2
         - multidict >=6.0.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,7 @@ outputs:
         - typing_extensions
       run_constrained:
         - jinja2 >=3.1.2
-        - pyjwt>=2.9.0
+        - pyjwt >=2.9.0
         - mako>=1.2.4
         - minijinja>=1.0.0
         - hiredis >=4.4.4,<5.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set name = "litestar" %}
+{% set name = "litestar" %}
 {% set version = "2.21.1" %}
 
 package:


### PR DESCRIPTION
## litestar 2.21.1

**Destination channel:** defaults

### Links

- [PKG-13102](https://anaconda.atlassian.net/browse/PKG-13102)
- [PyPI](https://pypi.org/project/litestar/2.21.1/)
- [Upstream repository](https://github.com/litestar-org/litestar)
- Relevant dependency PRs:
  - [rich-click 1.9.7](https://github.com/AnacondaRecipes/rich-click-feedstock/pull/4)
  - [polyfactory 3.3.0](https://github.com/AnacondaRecipes/polyfactory-feedstock/pull/3)
  - [litestar-htmx 0.5.0](https://github.com/AnacondaRecipes/litestar-htmx-feedstock/pull/1)

### Explanation of changes:

- Updated litestar from 2.12.1 to 2.21.1
- Source URL fixed from pypi.io to pypi.org
- Added 3 new core dependencies: litestar-htmx >=0.4.0, multipart >=1.2.0, sniffio >=1.3.1
- Updated exceptiongroup version pin to >=1.2.2 (matching upstream)
- Removed dead importlib-metadata/importlib-resources lines (py<39/py<310 never built)
- Added litestar --help entry point test
- Removed noarch:generic from litestar-with-brotli (broke pin_subpackage exact=True on non-linux-64)

> **Note:** `abs.yaml` currently contains `staging_channel_upload_target`, `channels`, and `build_parameters` entries for the evidently dependency chain bootstrap. These will be removed (abs.yaml cleaned up) in a follow-up commit once the PR is approved and before final merge to master.

[PKG-13102]: https://anaconda.atlassian.net/browse/PKG-13102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ